### PR TITLE
fix: replace bwolf references after fork

### DIFF
--- a/deploy/cert-manager-webhook-gandi/values.yaml
+++ b/deploy/cert-manager-webhook-gandi/values.yaml
@@ -1,4 +1,4 @@
-groupName: acme.bwolf.me
+groupName: acme.molnett.net
 logLevel: 6
 certManager:
   namespace: cert-manager

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/bwolf/cert-manager-webhook-gandi
+module github.com/molnett/cert-manager-webhook-gandi
 
 go 1.21
 


### PR DESCRIPTION
I wasn't aware we left two references to the old repo after forking until I read #3 